### PR TITLE
feat(web): apply error handling filter

### DIFF
--- a/cli/src/main/java/com/apighost/cli/server/JettyServer.java
+++ b/cli/src/main/java/com/apighost/cli/server/JettyServer.java
@@ -2,17 +2,9 @@ package com.apighost.cli.server;
 
 import com.apighost.cli.util.ConsoleOutput;
 import com.apighost.web.filter.CorsFilter;
+import com.apighost.web.filter.ErrorHandlingFilter;
 import com.apighost.web.servlet.ApiFrontControllerServlet;
 import jakarta.servlet.DispatcherType;
-import jakarta.servlet.Filter;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.FilterConfig;
-import jakarta.servlet.RequestDispatcher;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
-import jakarta.servlet.http.HttpServletRequest;
-import java.io.IOException;
 import java.net.URL;
 import java.util.EnumSet;
 import org.eclipse.jetty.ee10.servlet.FilterHolder;
@@ -51,7 +43,6 @@ public class JettyServer {
     public void start() throws Exception {
 
         server = new Server(port);
-
         /** GUI Path */
         WebAppContext uiContext = new WebAppContext();
         uiContext.setContextPath("/apighost-ui");
@@ -93,6 +84,10 @@ public class JettyServer {
         }
 
         /** SERVLET injection implemented in WebAppContext in Web module & Add CORS Filters */
+
+        FilterHolder errorHandlingFilterHolder = new FilterHolder(new ErrorHandlingFilter());
+        apiContext.addFilter(errorHandlingFilterHolder, "/apighost/*", EnumSet.of(DispatcherType.REQUEST));
+
         FilterHolder corsFilterHolder = new FilterHolder(new CorsFilter());
         apiContext.addFilter(corsFilterHolder, "/apighost/*", EnumSet.of(DispatcherType.REQUEST));
 

--- a/web/src/main/java/com/apighost/web/controller/ApiController.java
+++ b/web/src/main/java/com/apighost/web/controller/ApiController.java
@@ -18,22 +18,22 @@ public interface ApiController {
 
     default void doGet(HttpServletRequest request, HttpServletResponse response)
         throws ServletException, IOException {
-        response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        throw new UnsupportedOperationException();
     }
 
     default void doPost(HttpServletRequest request, HttpServletResponse response)
         throws ServletException, IOException {
-        response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        throw new UnsupportedOperationException();
     }
 
     default void doPut(HttpServletRequest request, HttpServletResponse response)
         throws ServletException, IOException {
-        response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        throw new UnsupportedOperationException();
     }
 
     default void doDelete(HttpServletRequest request, HttpServletResponse response)
         throws ServletException, IOException {
-        response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        throw new UnsupportedOperationException();
     }
 }
 

--- a/web/src/main/java/com/apighost/web/controller/EndpointController.java
+++ b/web/src/main/java/com/apighost/web/controller/EndpointController.java
@@ -41,15 +41,9 @@ public class EndpointController implements ApiController {
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response)
         throws ServletException, IOException {
-        try {
-            List<Endpoint> endpointList = apiCollector.getEndPointList();
-            JsonUtils.writeJsonResponse(response, endpointList,
-                HttpServletResponse.SC_OK);
-        } catch (Exception e) {
-            JsonUtils.writeErrorResponse(response,
-                "Failed to get endpoint: " + e.getMessage(),
-                HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-        }
+
+        List<Endpoint> endpointList = apiCollector.getEndPointList();
+        JsonUtils.writeJsonResponse(response, endpointList, HttpServletResponse.SC_OK);
 
     }
 }

--- a/web/src/main/java/com/apighost/web/controller/ResultInfoController.java
+++ b/web/src/main/java/com/apighost/web/controller/ResultInfoController.java
@@ -10,6 +10,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 
 /**
@@ -69,14 +70,11 @@ public class ResultInfoController implements ApiController {
             }
 
             if (!found) {
-                JsonUtils.writeErrorResponse(response, "No matching scenario result found.",
-                    HttpServletResponse.SC_NOT_FOUND);
+                throw new FileNotFoundException("No matching scenario result found.");
             }
 
         } catch (Exception e) {
-            JsonUtils.writeErrorResponse(response,
-                "Failed to get scenario result detail: " + e.getMessage(),
-                HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            throw new IllegalStateException("Failed to get scenario result detail: " + e.getMessage());
         }
     }
 }

--- a/web/src/main/java/com/apighost/web/controller/ResultListController.java
+++ b/web/src/main/java/com/apighost/web/controller/ResultListController.java
@@ -70,8 +70,7 @@ public class ResultListController implements ApiController {
             JsonUtils.writeJsonResponse(response, result, HttpServletResponse.SC_OK);
 
         } catch (Exception e) {
-            JsonUtils.writeErrorResponse(response, "Failed to get scenario list: " + e.getMessage(),
-                HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            throw new RuntimeException("Failed to get scenario list: " + e.getMessage());
         }
     }
 }

--- a/web/src/main/java/com/apighost/web/controller/ScenarioInfoController.java
+++ b/web/src/main/java/com/apighost/web/controller/ScenarioInfoController.java
@@ -10,6 +10,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -59,28 +60,21 @@ public class ScenarioInfoController implements ApiController {
                                                        name.toLowerCase().endsWith(".yml")
             );
 
-            boolean isFound = false;
             for (File file : files) {
                 String searchedName = file.getName();
 
                 if (searchedName.equals(scenarioName)) {
                     Scenario scenario = reader.readScenario(file.getAbsolutePath());
                     JsonUtils.writeJsonResponse(response, scenario, HttpServletResponse.SC_OK);
-                    isFound = true;
                     return;
                 }
             }
 
             /** Return an error without the file found*/
-            if (!isFound) {
-                JsonUtils.writeErrorResponse(response, "No matching scenario found.",
-                    HttpServletResponse.SC_NOT_FOUND);
-            }
+            throw new FileNotFoundException("No matching scenario found.");
 
         } catch (Exception e) {
-            JsonUtils.writeErrorResponse(response,
-                "Failed to get scenario list: " + e.getMessage(),
-                HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            throw new RuntimeException("Failed to get scenario list: " + e.getMessage());
         }
     }
 }

--- a/web/src/main/java/com/apighost/web/controller/ScenarioListController.java
+++ b/web/src/main/java/com/apighost/web/controller/ScenarioListController.java
@@ -57,8 +57,7 @@ public class ScenarioListController implements ApiController {
             JsonUtils.writeJsonResponse(response, result, HttpServletResponse.SC_OK);
 
         } catch (Exception e) {
-            JsonUtils.writeErrorResponse(response, "Failed to get scenario list: " + e.getMessage(),
-                HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            throw new RuntimeException("Failed to get scenario list: " + e.getMessage());
         }
     }
 }

--- a/web/src/main/java/com/apighost/web/controller/ScenarioTestController.java
+++ b/web/src/main/java/com/apighost/web/controller/ScenarioTestController.java
@@ -51,18 +51,13 @@ public class ScenarioTestController implements ApiController {
         throws ServletException, IOException {
         /** Confirmation of asynchronous support */
         if (!request.isAsyncSupported()) {
-            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-            JsonUtils.writeErrorResponse(response, "Async not supported",
-                HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-            return;
+            throw new IllegalStateException("Async not supported");
         }
 
         /** Get scenario name parameter */
         String scenarioName = request.getParameter("scenarioName");
         if (scenarioName == null || scenarioName.isEmpty()) {
-            JsonUtils.writeErrorResponse(response, "Missing required parameter: scenarioName",
-                HttpServletResponse.SC_BAD_REQUEST);
-            return;
+            throw new IllegalArgumentException("Missing required parameter: scenarioName");
         }
 
         /** Set up async context

--- a/web/src/main/java/com/apighost/web/filter/ErrorHandlingFilter.java
+++ b/web/src/main/java/com/apighost/web/filter/ErrorHandlingFilter.java
@@ -11,15 +11,45 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-
+/**
+ * A servlet filter that handles uncaught exceptions during request processing and
+ * writes appropriate JSON error responses based on the exception type.
+ *
+ * <p>This filter intercepts any thrown exceptions from downstream filters or servlets,
+ * resolves them to a predefined {@link ErrorCode}, and writes a structured JSON response
+ * using {@link JsonUtils}.
+ *
+ * <p>Typical usage involves registering this filter in a Spring Boot or servlet container
+ * context to ensure consistent error responses across the application.
+ *
+ *
+ * @author oneweeek
+ * @version BETA-0.0.1
+ */
 public class ErrorHandlingFilter implements Filter {
 
-
+    /**
+     * Initializes the filter. No specific configuration is applied in this implementation.
+     *
+     * @param filterConfig the filter configuration provided by the container
+     * @throws ServletException if an initialization error occurs
+     */
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
         Filter.super.init(filterConfig);
     }
 
+    /**
+     * Applies filtering logic by forwarding the request and catching any thrown exceptions.
+     * On exception, it handles the error by resolving an appropriate {@link ErrorCode} and
+     * writing a JSON response.
+     *
+     * @param request the incoming {@link ServletRequest}
+     * @param response the outgoing {@link ServletResponse}
+     * @param filterChain the filter chain to pass the request along
+     * @throws IOException if an I/O error occurs during processing
+     * @throws ServletException if a servlet-specific error occurs
+     */
     @Override
     public void doFilter(ServletRequest request, ServletResponse response,
         FilterChain filterChain) throws IOException, ServletException {
@@ -31,6 +61,14 @@ public class ErrorHandlingFilter implements Filter {
         }
     }
 
+    /**
+     * Resolves the error code from the given exception and writes the error response
+     * using {@link JsonUtils}. Includes the exception message if it is non-empty and meaningful.
+     *
+     * @param response the {@link HttpServletResponse} to write to
+     * @param e the exception to handle
+     * @throws IOException if an error occurs while writing the response
+     */
     private void handleException(HttpServletResponse response, Throwable e) throws IOException {
         ErrorCode errorCode = resolveErrorCode(e);
         String message = e.getMessage();
@@ -41,6 +79,12 @@ public class ErrorHandlingFilter implements Filter {
         }
     }
 
+    /**
+     * Maps the given exception to a corresponding {@link ErrorCode}.
+     *
+     * @param e the exception to resolve
+     * @return the resolved {@link ErrorCode}
+     */
     private ErrorCode resolveErrorCode(Throwable e) {
         if (e instanceof FileNotFoundException) {
             return ErrorCode.FILE_NOT_FOUND;
@@ -66,6 +110,9 @@ public class ErrorHandlingFilter implements Filter {
         return ErrorCode.INTERNAL_SERVER_ERROR;
     }
 
+    /**
+     * Destroys the filter. No cleanup is required in this implementation.
+     */
     @Override
     public void destroy() {
         Filter.super.destroy();

--- a/web/src/main/java/com/apighost/web/filter/ErrorHandlingFilter.java
+++ b/web/src/main/java/com/apighost/web/filter/ErrorHandlingFilter.java
@@ -1,0 +1,73 @@
+package com.apighost.web.filter;
+
+import com.apighost.web.util.ErrorCode;
+import com.apighost.web.util.JsonUtils;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+public class ErrorHandlingFilter implements Filter {
+
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        Filter.super.init(filterConfig);
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response,
+        FilterChain filterChain) throws IOException, ServletException {
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+        try {
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            handleException(httpResponse, e);
+        }
+    }
+
+    private void handleException(HttpServletResponse response, Throwable e) throws IOException {
+        ErrorCode errorCode = resolveErrorCode(e);
+        String message = e.getMessage();
+        if (message != null && !message.trim().isEmpty() && !message.toLowerCase().contains("null")) {
+            JsonUtils.writeErrorResponse(response, errorCode, message);
+        } else {
+            JsonUtils.writeErrorResponse(response, errorCode);
+        }
+    }
+
+    private ErrorCode resolveErrorCode(Throwable e) {
+        if (e instanceof FileNotFoundException) {
+            return ErrorCode.FILE_NOT_FOUND;
+        }
+        if (e instanceof UnsupportedOperationException){
+            return ErrorCode.METHOD_NOT_ALLOWED;
+        }
+        if (e instanceof IllegalArgumentException) {
+            if (e.getMessage() != null && e.getMessage().contains("Controller not found")) {
+                return ErrorCode.CONTROLLER_NOT_FOUND;
+            }
+            return ErrorCode.INVALID_PARAMETER;
+        }
+        if (e instanceof IllegalStateException) {
+            return ErrorCode.ILLEGAL_STATE;
+        }
+        if (e instanceof IOException) {
+            return ErrorCode.IO_ERROR;
+        }
+        if (e instanceof Exception) {
+            return ErrorCode.INTERNAL_SERVER_ERROR;
+        }
+        return ErrorCode.INTERNAL_SERVER_ERROR;
+    }
+
+    @Override
+    public void destroy() {
+        Filter.super.destroy();
+    }
+}

--- a/web/src/main/java/com/apighost/web/servlet/ApiFrontControllerServlet.java
+++ b/web/src/main/java/com/apighost/web/servlet/ApiFrontControllerServlet.java
@@ -8,7 +8,6 @@ import com.apighost.web.controller.ScenarioExportController;
 import com.apighost.web.controller.ScenarioInfoController;
 import com.apighost.web.controller.ScenarioListController;
 import com.apighost.web.controller.ScenarioTestController;
-import com.apighost.web.util.JsonUtils;
 import jakarta.servlet.*;
 import jakarta.servlet.http.*;
 import java.io.IOException;
@@ -51,8 +50,7 @@ public class ApiFrontControllerServlet extends HttpServlet {
 
         /** only handle /apighost/xxx URL */
         if (!path.startsWith("/apighost/")) {
-            response.sendError(HttpServletResponse.SC_NOT_FOUND);
-            return;
+            throw new IllegalArgumentException("Invalid URL path: " + path);
         }
 
         /** Controller key extraction (/apighost/scenario-list -> scenario-list) */
@@ -61,8 +59,7 @@ public class ApiFrontControllerServlet extends HttpServlet {
         /** Controller inquiry */
         ApiController controller = controllerMap.get(controllerKey);
         if (controller == null) {
-            response.sendError(HttpServletResponse.SC_NOT_FOUND);
-            return;
+            throw new IllegalArgumentException("Controller not found for path: " + controllerKey);
         }
 
         /** Request processing */
@@ -81,11 +78,10 @@ public class ApiFrontControllerServlet extends HttpServlet {
                     controller.doDelete(request, response);
                     break;
                 default:
-                    response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+                    throw new UnsupportedOperationException();
             }
         } catch (Exception e) {
-            JsonUtils.writeErrorResponse(response, "Server error: " + e.getMessage(),
-                HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            throw new RuntimeException("Server error: " + e.getMessage());
         }
     }
 

--- a/web/src/main/java/com/apighost/web/util/ErrorCode.java
+++ b/web/src/main/java/com/apighost/web/util/ErrorCode.java
@@ -1,0 +1,45 @@
+package com.apighost.web.util;
+
+public enum ErrorCode {
+    INVALID_PARAMETER(400, "Invalid parameter."),
+    INVALID_JSON_FORMAT(400, "Invalid JSON format."),
+    RESOURCE_NOT_FOUND(404, "The requested resource was not found."),
+    CONTROLLER_NOT_FOUND(404,  "The requested controller was not found."),
+    FILE_NOT_FOUND(404, "The requested file was not found."),
+    METHOD_NOT_ALLOWED(405,  "Method not allowed."),
+    ILLEGAL_STATE(409, "Invalid state change requested."),
+    IO_ERROR(500, "An error occurred during an input/output operation."),
+    CLASS_NOT_FOUND(500, "The requested class was not found."),
+    INTERNAL_SERVER_ERROR(500, "An internal server error has occurred.");
+    private final int httpStatus;
+    private final String message;
+
+    /**
+     * Constructs an ErrorCode with the specified HTTP status, code, and message.
+     *
+     * @param httpStatus the HTTP status associated with the error
+     * @param message the default error message
+     */
+    ErrorCode(int httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    /**
+     * Gets the HTTP status associated with the error.
+     *
+     * @return the HTTP status
+     */
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+
+    /**
+     * Gets the default error message.
+     *
+     * @return the error message
+     */
+    public String getMessage() {
+        return message;
+    }
+}

--- a/web/src/main/java/com/apighost/web/util/ErrorCode.java
+++ b/web/src/main/java/com/apighost/web/util/ErrorCode.java
@@ -1,5 +1,20 @@
 package com.apighost.web.util;
-
+/**
+ * Defines a set of error codes used for standardized error responses across the application.
+ *
+ * <p>Each error code is associated with an HTTP status code and a default error message.
+ * These values are used to generate consistent JSON error responses for various failure scenarios.
+ *
+ * <p>Typical usage:
+ * <pre>
+ *     ErrorCode errorCode = ErrorCode.INVALID_PARAMETER;
+ *     int status = errorCode.getHttpStatus();
+ *     String message = errorCode.getMessage();
+ * </pre>
+ *
+ * @author oneweeek
+ * @version BETA-0.0.1
+ */
 public enum ErrorCode {
     INVALID_PARAMETER(400, "Invalid parameter."),
     INVALID_JSON_FORMAT(400, "Invalid JSON format."),
@@ -11,6 +26,7 @@ public enum ErrorCode {
     IO_ERROR(500, "An error occurred during an input/output operation."),
     CLASS_NOT_FOUND(500, "The requested class was not found."),
     INTERNAL_SERVER_ERROR(500, "An internal server error has occurred.");
+
     private final int httpStatus;
     private final String message;
 

--- a/web/src/main/java/com/apighost/web/util/JsonUtils.java
+++ b/web/src/main/java/com/apighost/web/util/JsonUtils.java
@@ -24,28 +24,52 @@ public class JsonUtils {
         writer.flush();
     }
 
-    public static void writeErrorResponse(HttpServletResponse response, String errorMessage, int statusCode)
+    public static void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode)
         throws IOException {
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        response.setStatus(statusCode);
+        response.setStatus(errorCode.getHttpStatus());
 
         String jsonString = objectMapper.writeValueAsString(
-            new ErrorResponse(errorMessage));
+            new ErrorResponse(errorCode));
+        PrintWriter writer = response.getWriter();
+        writer.write(jsonString);
+        writer.flush();
+    }
+
+    public static void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode, String message)
+        throws IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(errorCode.getHttpStatus());
+
+        String jsonString = objectMapper.writeValueAsString(
+            new ErrorResponse(errorCode, message));
         PrintWriter writer = response.getWriter();
         writer.write(jsonString);
         writer.flush();
     }
 
     private static class ErrorResponse {
-        private final String error;
+        private final int status;
+        private final String message;
 
-        public ErrorResponse(String error) {
-            this.error = error;
+        public ErrorResponse(ErrorCode errorCode, String message) {
+            this.status = errorCode.getHttpStatus();
+            this.message = message;
         }
 
-        public String getError() {
-            return error;
+        public ErrorResponse(ErrorCode errorCode) {
+            this.status = errorCode.getHttpStatus();
+            this.message = errorCode.getMessage();
+        }
+
+        public int getStatus() {
+            return status;
+        }
+
+        public String getMessage() {
+            return message;
         }
     }
 }

--- a/web/src/main/java/com/apighost/web/util/JsonUtils.java
+++ b/web/src/main/java/com/apighost/web/util/JsonUtils.java
@@ -5,13 +5,32 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
-
+/**
+ * Utility class for writing JSON responses to {@link HttpServletResponse} objects.
+ *
+ * <p>This class provides methods to serialize objects into JSON using Jackson
+ * and write them directly to the HTTP response stream. It also includes
+ * specialized methods for writing standardized error responses using {@link ErrorCode}.
+ *
+ * <p>All responses are written with UTF-8 encoding and the
+ * <code>application/json</code> content type.
+ *
+ * @author sun-jun98
+ * @version BETA-0.0.1
+ */
 public class JsonUtils {
 
     private static final ObjectMapper objectMapper = new ObjectMapper()
                                                          .enable(
                                                              SerializationFeature.INDENT_OUTPUT);
-
+    /**
+     * Writes a JSON response to the given {@link HttpServletResponse} using the specified object and status code.
+     *
+     * @param response the HTTP response to write to
+     * @param object the object to serialize as JSON
+     * @param statusCode the HTTP status code to set
+     * @throws IOException if an I/O error occurs while writing the response
+     */
     public static void writeJsonResponse(HttpServletResponse response, Object object, int statusCode)
         throws IOException {
         response.setContentType("application/json");
@@ -24,6 +43,14 @@ public class JsonUtils {
         writer.flush();
     }
 
+    /**
+     * Writes a JSON-formatted error response using the specified {@link ErrorCode}.
+     * The default message from the error code will be used.
+     *
+     * @param response the HTTP response to write to
+     * @param errorCode the error code indicating the type of error
+     * @throws IOException if an I/O error occurs while writing the response
+     */
     public static void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode)
         throws IOException {
         response.setContentType("application/json");
@@ -37,6 +64,15 @@ public class JsonUtils {
         writer.flush();
     }
 
+    /**
+     * Writes a JSON-formatted error response using the specified {@link ErrorCode}
+     * and a custom error message.
+     *
+     * @param response the HTTP response to write to
+     * @param errorCode the error code indicating the type of error
+     * @param message the custom error message to include in the response
+     * @throws IOException if an I/O error occurs while writing the response
+     */
     public static void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode, String message)
         throws IOException {
         response.setContentType("application/json");
@@ -50,6 +86,9 @@ public class JsonUtils {
         writer.flush();
     }
 
+    /**
+     * Represents a standardized error response object used for JSON serialization.
+     */
     private static class ErrorResponse {
         private final int status;
         private final String message;


### PR DESCRIPTION
<!--
Thank you for contributing to the API GHOST project.
This document provides guidelines to ensure smooth collaboration and maintain high code quality.
-->

<!--
PR Title Format Guideline

Use the following format for your PR title:

    type(scope): concise description

Examples:
    feat(api): add scenario execution support
    fix(parser): resolve YAML parsing error
    docs(readme): update CLI usage instructions

Available types:
    feat:     Add a new feature
    fix:      Fix a bug
    build:    Modify build system or external dependencies
    chore:    Modify configuration files unrelated to source or test files (e.g., .gitignore, .editorconfig)
    ci:       Update CI configuration files and scripts
    test:     Add or update tests
    docs:     Update documentation (e.g., README)
    refactor: Code changes that neither fix a bug nor add a feature
    style:    modify CSS styles
-->

### Related Issue

- #50 
### Description

- ErrorHandling Filter was applied globally to all requests (/apighost/*) to unify the error response format to JSON.
- Instead of the Jetty default error page, we processed a custom JSON response to be returned.

### Testing

- After running the Jetty server locally, I checked the following cases:
- Check JSON error response for invalid controller requests (/apighost/invalid-key)
- Check JSON error response on non-existent URL requests (/unknow)

### Additional Notes

- Exceptions from /apighost/* off-paths are also returned in consistent JSON format.

### Pre-Submission Checklist

- [x] Have you completed code style (convention) checks locally?
- [x] Have you passed the CI tests in your local environment?
